### PR TITLE
Handle javascript events when plugin name includes capital letters

### DIFF
--- a/lib/handlebars/javascript.js
+++ b/lib/handlebars/javascript.js
@@ -81,5 +81,6 @@ handlebars.registerHelper('formatJsOptionValue', function(name) {
  * @returns {string} Formatted event name.
  */
 handlebars.registerHelper('formatJsEventName', function(name, title) {
-  return format('{0}.zf.{1}', [name, title.toLowerCase().replace(/(-| )/, '')]);
+  title = title.charAt(0).toLowerCase() + title.slice(1);
+  return format('{0}.zf.{1}', [name, title.replace(/(-| )/, '')]);
 });


### PR DESCRIPTION
Fix an issue when javascript event's plugin name contains capital letters (like `accordionMenu` in zurb/foundation-sites#8363).

It still lowers the first letter but not the following ones.