### PR TITLE
Add padding for code samples.

### DIFF
--- a/scss/_code.scss
+++ b/scss/_code.scss
@@ -8,6 +8,7 @@ pre {
     display: block;
     overflow-x: auto;
     padding: 1rem;
+    padding-right: 4rem;
     background: #f9f9f9;
     margin-bottom: 1.5rem;
   }


### PR DESCRIPTION
On some code examples - the "Copy" button covers part of the code so you can't see all of the code example. I've added padding to the code tag so the code can always be seen. 

I've uploaded a screenshot to tinypic as an example of the issue: http://i65.tinypic.com/8vu1lc.png

<a href="http://tinypic.com?ref=8vu1lc" target="_blank"><img src="http://i65.tinypic.com/8vu1lc.png" border="0" alt="Image and video hosting by TinyPic"></a>