### PR TITLE
Fix docs of JS options

### DIFF
--- a/lib/handlebars/formatting.js
+++ b/lib/handlebars/formatting.js
@@ -77,3 +77,12 @@ handlebars.registerHelper('filter', function(item, options) {
   if (item.access === 'private' || item.alias) return '';
   return options.fn(this);
 });
+
+/**
+ * Render a JSON string from an Object. Useful mostly for debug.
+ * @param {object} value - Object to display in a JSON format.
+ * @returns {string} JSON formatted string.
+ */
+handlebars.registerHelper('formatJson', function(value) {
+    return JSON.stringify(value);
+});

--- a/lib/handlebars/javascript.js
+++ b/lib/handlebars/javascript.js
@@ -60,6 +60,23 @@ handlebars.registerHelper('formatJsOptionName', function(name) {
 });
 
 /**
+ * Formats JsDoc "type" definitions to read "x or y or z"
+ * @param {string[]} types - Array of types.
+ * @returns {string} A formatted string.
+ */
+handlebars.registerHelper('formatJsOptionTypes', function(types) {
+  if (typeof types === 'undefined' || typeof types.names == 'undefined') return '';
+  var types = types.names;
+  var output = '';
+
+  for (var i in types) {
+    output += types[i] + ' or ';
+  }
+
+  return output.slice(0, -4);
+});
+
+/**
  * Format a JavaScript plugin option's default value:
  *   - For string values, remove the quotes on either side.
  *   - For all other values, return as-is.

--- a/lib/handlebars/javascript.js
+++ b/lib/handlebars/javascript.js
@@ -68,7 +68,6 @@ handlebars.registerHelper('formatJsOptionName', function(name) {
  */
 handlebars.registerHelper('formatJsOptionValue', function(name) {
   if (typeof name === 'undefined') return '';
-  name = name[0];
   if (name.match(/^('|").+('|")$/)) return name.slice(1, -1);
   else return name;
 });

--- a/templates/partials/javascript-reference.hbs
+++ b/templates/partials/javascript-reference.hbs
@@ -64,7 +64,7 @@
       {{#each js.member}}
       <tr>
         <td><code>{{formatJsOptionName this.name}}</code></td>
-        <td><code>{{formatJsOptionValue this.examples}}</code></td>
+        <td><code>{{formatJsOptionValue this.defaultvalue}}</code></td>
         <td>{{this.description}}</td>
       </tr>
       {{/each}}

--- a/templates/partials/javascript-reference.hbs
+++ b/templates/partials/javascript-reference.hbs
@@ -59,11 +59,17 @@
 
     <table class="docs-variable-table">
       <thead>
-        <tr><th>Name</th><th>Default</th><th>Description</th></tr>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Default</th>
+          <th>Description</th>
+        </tr>
       </thead>
       {{#each js.member}}
       <tr>
         <td><code>{{formatJsOptionName this.name}}</code></td>
+        <td><code>{{formatJsOptionTypes this.type}}</code></td>
         <td><code>{{formatJsOptionValue this.defaultvalue}}</code></td>
         <td>{{this.description}}</td>
       </tr>


### PR DESCRIPTION
See: https://github.com/zurb/foundation-sites/pull/9562

#### Changes:
- Display `@default` instead of `@example`.
- Display `@type`.

#### Other changes:
- Add `formatJson` Handlebar filter to help debug.