### PR TITLE
Off-canvas sticky attribute

### DIFF
--- a/templates/partials/table-of-contents.hbs
+++ b/templates/partials/table-of-contents.hbs
@@ -1,5 +1,5 @@
 <nav class="docs-toc-wrap" id="docsToc" data-sticky-container>
-  <div class="docs-toc hide" id="docsTOC" data-sticky data-margin-top="6" data-anchor="docs">
+  <div class="docs-toc hide" id="docsTOC" data-sticky data-off-canvas-sticky data-margin-top="6" data-anchor="docs">
     <ul class="vertical menu" data-docs-toc>
       <li class="docs-nav-title">{{ title }}</li>
     </ul>


### PR DESCRIPTION
This PR adds the new attribute to the side table-of-contents so it gets pseudo fixed on opening a push off-canvas on the foundation-sites docs page

It refers to this PR:
https://github.com/zurb/foundation-sites/pull/10381

