### PR TITLE
Add link to slack channel inviter

### DIFF
--- a/templates/partials/table-of-contents.hbs
+++ b/templates/partials/table-of-contents.hbs
@@ -9,7 +9,8 @@
     <ul class="docs-contribute-menu">
       <li><a href="{{ editLink repoName editBranch fileName }}" target="_blank"><i class="fi-pencil"></i>Edit this Page</a></li>
       <li><a href="{{#if library}}{{ library.github }}/issues{{else}}{{ issueLink repoName title }}{{/if}}" target="_blank"><i class="fi-social-github"></i>Report a Bug</a></li>
-        <li><a href="http://foundation.zurb.com/forum?search={{title}}" target="_blank"><i class="fi-comment"></i>Get Help</a></li>
+      <li><a href="http://foundation.zurb.com/forum?search={{title}}" target="_blank"><i class="fi-comment"></i>Get Help</a></li>
+      <li><a href="https://zurb-foundation-slack-invites.herokuapp.com/" target="_blank">Join Slack Channel</a></li>
     </ul>
     <div class="foundation-toc-ad-unit" id="TOCAdUnit"></div>
   </div>


### PR DESCRIPTION
No icon as we don't have one in foundation-icons (used by docs) and it wasn't obvious how to add images given the funky build system we use for these layouts, but I think better than nothing.