### PR TITLE
Changed the Magellan initialization on Table of Content

### DIFF
--- a/js/docs.tableOfContents.js
+++ b/js/docs.tableOfContents.js
@@ -17,13 +17,6 @@ $h2s.each(function() {
   $toc.append('<li><a href="'+anchor+'">'+text+'</a></li>');
 });
 
-// Initialize Magellan on the generated table of contents
-if ($toc.length) {
-  if (typeof Foundation !== 'undefined') {
-    new Foundation.Magellan($toc, {offset: 130});
-  }
-}
-
 }();
 
 //var $window = $(window);

--- a/templates/partials/table-of-contents.hbs
+++ b/templates/partials/table-of-contents.hbs
@@ -1,6 +1,6 @@
 <nav class="docs-toc-wrap" id="docsToc" data-sticky-container>
   <div class="docs-toc hide" id="docsTOC" data-sticky data-margin-top="6" data-anchor="docs">
-    <ul class="vertical menu" data-docs-toc>
+    <ul class="vertical menu" data-docs-toc data-magellan data-offset="130">
       <li class="docs-nav-title">{{ title }}</li>
     </ul>
 


### PR DESCRIPTION
That programmatic initialization causes the following default warning message when `$(document).foundation()` is called :
**Tried to initialize magellan on an element that already has a Foundation plugin.**
Therefore, there is no need to initialize that plugin _programmatically_ while it can be done by adding the proper attribute `data-magellan`.
