### PR TITLE
fix: generate event names from the event scope

### DIFF
--- a/templates/partials/javascript-reference.hbs
+++ b/templates/partials/javascript-reference.hbs
@@ -104,7 +104,7 @@
       </thead>
       {{#each js.event}}
         <tr>
-          <td><code>{{formatJsEventName this.name ../title}}</code></td>
+          <td><code>{{formatJsEventName this.name this.memberof}}</code></td>
           <td>{{this.description}}</td>
         </tr>
       {{/each}}


### PR DESCRIPTION
Generate event names from the event scope instead of the page title

Closes:
- https://github.com/zurb/foundation-sites/issues/7914
- https://github.com/zurb/foundation-sites/issues/9151

Related to:
- https://github.com/zurb/foundation-sites/pull/10555
- https://github.com/zurb/foundation-sites/pull/10932
-  https://github.com/zurb/foundation-sites/pull/10933