### PR TITLE
chore: resolve dependencies CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1395,7 +1395,7 @@
     },
     "capture-stack-trace": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
@@ -1928,7 +1928,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
@@ -5681,7 +5681,7 @@
         "espree": "3.1.7",
         "js2xmlparser": "1.0.0",
         "klaw": "1.3.1",
-        "marked": "0.3.9",
+        "marked": "0.3.14",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -5759,7 +5759,7 @@
             "escape-string-regexp": "1.0.5",
             "js2xmlparser": "3.0.0",
             "klaw": "2.0.0",
-            "marked": "0.3.9",
+            "marked": "0.3.14",
             "mkdirp": "0.5.1",
             "requizzle": "0.2.1",
             "strip-json-comments": "2.0.1",
@@ -6639,9 +6639,9 @@
       }
     },
     "marked": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
-      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.14.tgz",
+      "integrity": "sha512-3emDbXi5/Jnv8Pff4GdrBxJhpQA2xzq/IzHGjsVvGZs7QK0wx1mg7rRy5UmP1T/Dt1RsWL8ikxIM3cHHGF/UJg=="
     },
     "memoize-decorator": {
       "version": "1.0.2",
@@ -7703,7 +7703,7 @@
         "handlebars": "4.0.11",
         "highlight.js": "8.9.1",
         "js-yaml": "3.10.0",
-        "marked": "0.3.9",
+        "marked": "0.3.14",
         "nopt": "4.0.1",
         "slash": "1.0.0",
         "strip-bom": "2.0.0",
@@ -8871,7 +8871,7 @@
       "integrity": "sha512-yraBgRmjJ+YG+3FgRcKEy39RSFOV8Ri2ODGt/bb3Lxwmq0uK/3cAhzZEIdrYXPKeyfpWqpeTbtKWNuznyGZcfQ==",
       "dev": true,
       "requires": {
-        "marked": "0.3.9"
+        "marked": "0.3.14"
       }
     },
     "sassdoc-theme-default": {
@@ -9773,7 +9773,7 @@
         "js-yaml": "3.10.0",
         "jsdoc-api": "1.2.4",
         "jsdoc3-parser": "1.1.0",
-        "marked": "0.3.9",
+        "marked": "0.3.14",
         "mkdirp": "0.5.1",
         "rimraf": "2.6.2",
         "sassdoc": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1395,7 +1395,7 @@
     },
     "capture-stack-trace": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
@@ -1928,7 +1928,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "http://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
@@ -9755,9 +9755,9 @@
       "dev": true
     },
     "supercollider": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/supercollider/-/supercollider-1.4.3.tgz",
-      "integrity": "sha512-MO0AizK32avV6T5SUnd6gKbsjFRpY9KW5kPYN5hXE9bpdjfXOxQMs1IIgdML+ortzUZEVH/EsalxCJ4A6m0DVg==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/supercollider/-/supercollider-1.4.4.tgz",
+      "integrity": "sha512-YjuID3+QdvdqNB0fZmZKvb6hsGhlMFqkblgwB+yg6QiUI7dAoJzloThcMtkzjJj8/zbADF+ePPB4sWbWVOYjGw==",
       "dev": true,
       "requires": {
         "async": "0.9.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "inky": "^1.2.6",
     "js-beautify": "^1.6.2",
     "kebab-case": "^1.0.0",
-    "marked": "^0.3.5",
+    "marked": "^0.3.14",
     "mkdirp": "^0.5.1",
     "multiline": "^1.0.2",
     "querystring": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "panini": "^1.2.0",
     "rimraf": "^2.5.2",
     "striptags": "^2.1.1",
-    "supercollider": "^1.4.3"
+    "supercollider": "^1.4.4"
   }
 }


### PR DESCRIPTION
### Changes:
* **Update `marked`**
  `^0.3.5` (_locked to `0.3.9`_) -> `^0.3.14` (_locked to `0.3.14`_)
  Updates the dependency locking file.
  Resolves [CVE 2017-1000427](https://nvd.nist.gov/vuln/detail/CVE-2017-1000427).
* **Update `supercollider`**
  `^1.4.3` (_locked to `1.4.3`_) -> `^1.4.4` (_locked to `1.4.4`_)
  See https://github.com/zurb/supercollider/pull/18 - chore: resolve `marked` CVE (@ncoden)
