### PR TITLE
fix: use display table for the thumnails in the docs

### DIFF
--- a/scss/_page.scss
+++ b/scss/_page.scss
@@ -56,12 +56,6 @@
   margin-bottom: 2.5rem;
 }
 
-.docs-component .thumbnail {
-  margin-left: auto;
-  margin-right: auto;
-  display: table;
-}
-
 .docs-component .callout code {
   background: rgba($code-background, 0.5);
 }

--- a/scss/_page.scss
+++ b/scss/_page.scss
@@ -59,7 +59,7 @@
 .docs-component .thumbnail {
   margin-left: auto;
   margin-right: auto;
-  display: block;
+  display: table;
 }
 
 .docs-component .callout code {


### PR DESCRIPTION
The styles of the thumbnails in the docs use `display: block`
 with auto margins on both sides for exemplary centering them.

But this does not work well with `display: block` on an a tag.
~~`display: table`~~ `text-center` on the parent works much better in this example which is just for the docs and demonstrating the thumbnails.

Closes https://github.com/zurb/foundation-sites/issues/11029