### PR TITLE
fix: add namespace to type class in Sass reference table

### DIFF
--- a/templates/partials/sass-reference.hbs
+++ b/templates/partials/sass-reference.hbs
@@ -15,7 +15,7 @@
       <tr>
         <td class="name"><code>${{this.context.name}}</code></td>
         <td>{{formatSassTypes this.type}}</td>
-        <td class="{{toLower this.type}}"><code>{{formatSassValue this.context.value}}</code></td>
+        <td class="zf-docs-type-{{toLower this.type}}"><code>{{formatSassValue this.context.value}}</code></td>
         <td>{{md this.description}}</td>
       </tr>
       {{/each}}


### PR DESCRIPTION
As per https://github.com/zurb/foundation-sites/pull/11102#issuecomment-376997365