### PR TITLE
fix: ensure Sass/Js default values to be escaped

### DIFF
--- a/lib/handlebars/formatting.js
+++ b/lib/handlebars/formatting.js
@@ -34,6 +34,11 @@ handlebars.registerHelper('heading', function(level, anchor, options) {
  */
 handlebars.registerHelper('escape', escape);
 
+handlebars.registerHelper('escapeHTML', function (str) {
+  return handlebars.Utils.escapeExpression(str);
+});
+
+
 /**
  * Capitalizes the first letter of a string.
  * @param {string} text - Text to convert.

--- a/templates/partials/javascript-reference.hbs
+++ b/templates/partials/javascript-reference.hbs
@@ -70,7 +70,7 @@
       <tr>
         <td><code>{{formatJsOptionName this.name}}</code></td>
         <td><code>{{formatJsOptionTypes this.type}}</code></td>
-        <td><code>{{formatJsOptionValue this.defaultvalue}}</code></td>
+        <td><code>{{escapeHTML (formatJsOptionValue this.defaultvalue)}}</code></td>
         <td>{{this.description}}</td>
       </tr>
       {{/each}}

--- a/templates/partials/sass-reference.hbs
+++ b/templates/partials/sass-reference.hbs
@@ -15,7 +15,7 @@
       <tr>
         <td class="name"><code>${{this.context.name}}</code></td>
         <td>{{formatSassTypes this.type}}</td>
-        <td class="{{toLower this.type}}"><code>{{formatSassValue this.context.value}}</code></td>
+        <td class="{{toLower this.type}}"><code>{{escapeHTML (formatSassValue this.context.value)}}</code></td>
         <td>{{md this.description}}</td>
       </tr>
       {{/each}}
@@ -64,7 +64,7 @@
         <tr>
           <td><code>${{this.name}}</code></td>
           <td>{{formatSassTypes this.type}}</td>
-          <td><code>{{formatSassValue this.default}}</code></td>
+          <td><code>{{escapeHTML (formatSassValue this.default)}}</code></td>
           <td>{{md this.description}}</td>
         </tr>
         {{/each}}
@@ -117,7 +117,7 @@
         <tr>
           <td><code>${{this.name}}</code></td>
           <td>{{formatSassTypes this.type}}</td>
-          <td><code>{{formatSassValue this.default}}</code></td>
+          <td><code>{{escapeHTML (formatSassValue this.default)}}</code></td>
           <td>{{md this.description}}</td>
         </tr>
         {{/each}}


### PR DESCRIPTION
Despite the expected Handlebars behavior (escaping everything "SafeString" is used), the HTML that may be in Sass and Js  values are not escaped. No option is used (like "noEscape") that would explain this behavior.

This pull request add the "escapeHTML" helper and ensure that Sass and Js values are always escaped.

Closes https://github.com/zurb/foundation-sites/issues/11501
See: https://handlebarsjs.com/reference.html