### PR TITLE
fix: don't escape formatting HTML in Sass/Js values helpers

### DIFF
--- a/lib/handlebars/javascript.js
+++ b/lib/handlebars/javascript.js
@@ -78,15 +78,19 @@ handlebars.registerHelper('formatJsOptionTypes', function(types) {
 
 /**
  * Format a JavaScript plugin option's default value:
- *   - For string values, remove the quotes on either side.
- *   - For all other values, return as-is.
+ *   - For string values, remove the quotes on either side and escape it.
+ *   - For all other values, return them escaped.
  * @param {string} value - Value to process.
  * @returns {string} Processed value.
  */
 handlebars.registerHelper('formatJsOptionValue', function(name) {
   if (typeof name === 'undefined') return '';
-  if (name.match(/^('|").+('|")$/)) return name.slice(1, -1);
-  else return name;
+
+  if (name.match(/^('|").+('|")$/)) {
+    name = name.slice(1, -1);
+  }
+
+  return handlebars.Utils.escapeExpression(name);
 });
 
 /**

--- a/lib/handlebars/sass.js
+++ b/lib/handlebars/sass.js
@@ -103,9 +103,9 @@ handlebars.registerHelper('formatSassTypes', function(types) {
 
 /**
  * Format a Sass value:
- *   - For basic values, return as-is.
- *   - For maps, render each item in the map on its own line.
- *   - For undefined values, return "None"
+ *   - For basic values, return it escaped.
+ *   - For maps, render each item in the map escaped and on its own line.
+ *   - For undefined values, return a formatted "None"
  * @param {string} value - Sass value to format.
  * @returns {string} A formatted value.
  */
@@ -113,10 +113,15 @@ handlebars.registerHelper('formatSassValue', function(value) {
   if (typeof value === 'undefined') return '<span style="color: #999;">None</span>';
 
   if (value[0] === '(' && value[value.length - 1] === ')') {
-    value = value.slice(1, -1).split(',').join('<br>');
+    var values = value.slice(1, -1).split(',');
+    var escapedValues = values.map(function (v) {
+      return handlebars.Utils.escapeExpression(v)
+    });
+
+    return escapedValues.join('<br>');
   }
 
-  return value;
+  return handlebars.Utils.escapeExpression(value);
 });
 
 // Adds an external link, pulled from a SassDock @link annotation.

--- a/templates/partials/sass-reference.hbs
+++ b/templates/partials/sass-reference.hbs
@@ -15,7 +15,7 @@
       <tr>
         <td class="name"><code>${{this.context.name}}</code></td>
         <td>{{formatSassTypes this.type}}</td>
-        <td class="{{toLower this.type}}"><code>{{escapeHTML (formatSassValue this.context.value)}}</code></td>
+        <td class="{{toLower this.type}}"><code>{{formatSassValue this.context.value}}</code></td>
         <td>{{md this.description}}</td>
       </tr>
       {{/each}}
@@ -64,7 +64,7 @@
         <tr>
           <td><code>${{this.name}}</code></td>
           <td>{{formatSassTypes this.type}}</td>
-          <td><code>{{escapeHTML (formatSassValue this.default)}}</code></td>
+          <td><code>{{formatSassValue this.default}}</code></td>
           <td>{{md this.description}}</td>
         </tr>
         {{/each}}
@@ -117,7 +117,7 @@
         <tr>
           <td><code>${{this.name}}</code></td>
           <td>{{formatSassTypes this.type}}</td>
-          <td><code>{{escapeHTML (formatSassValue this.default)}}</code></td>
+          <td><code>{{formatSassValue this.default}}</code></td>
           <td>{{md this.description}}</td>
         </tr>
         {{/each}}


### PR DESCRIPTION
Escape the Sass/Js values inside the helpers instead of outside if, so the internal HTML used for formatting is preserved.

This bug was introduced in https://github.com/zurb/foundation-docs/pull/36.