### PR TITLE
fix: trim and filter Js functions parameters to avoir leading comma

### DIFF
--- a/lib/handlebars/javascript.js
+++ b/lib/handlebars/javascript.js
@@ -28,16 +28,18 @@ handlebars.registerHelper('writeJsConstructor', function(name) {
  */
 handlebars.registerHelper('writeJsFunction', function(method) {
   var str = '$(\'#element\').foundation(\'' + method.name;
-  if (method.params) {
-    str += '\', ';
-    str += (method.params || []).map(function(val) {
-      return val.name;
-    }).join(', ');
-    str += ');';
+
+  if (method.params && method.params.length) {
+    var formattedParamList = method.params
+      .map(function (val) { return val.name.trim(); })
+      .filter(function (name) { return !!name.length; })
+      .join(', ');
+    str += '\', ' + formattedParamList + ');';
   }
   else {
     str += '\');'
   }
+
   return hljs.highlight('js', str).value;
 });
 


### PR DESCRIPTION
Trim and filters the method parameters in the `writeJsFunction` to avoir any empty parameter or leading comma.

For now, leading commas are generated because of empty arrays of methods with empty arrays of parameters, or with null-ish parameters.